### PR TITLE
Defer to jsonwebtoken library for validation.

### DIFF
--- a/src/api/token.rs
+++ b/src/api/token.rs
@@ -58,24 +58,12 @@ impl crate::FireAuth {
         let decoding_key = &DecodingKey::from_rsa_pem(decoding_key.as_bytes())
             .map_err(|_| Error::Token("Failed to parse decoding key!".into()))?;
 
-        // Decodes the ID token
-        let decoded =
+        // Decodes and validates the ID token.
+        Ok(
             decode::<IdTokenClaims>(id_token, decoding_key, &Validation::new(Algorithm::RS256))
                 .map_err(|_| Error::Token("Invalid ID token!".into()))?
-                .claims;
-        let timestamp = jsonwebtoken::get_current_timestamp();
-
-        // Checks if the token is expired
-        if decoded.exp <= timestamp {
-            return Err(Error::Token("Token is expired!".into()));
-        }
-
-        // Checks if the token is valid yet
-        if decoded.iat >= timestamp {
-            return Err(Error::Token("Token isn't valid yet!".into()));
-        }
-
-        Ok(decoded)
+                .claims,
+        )
     }
 }
 


### PR DESCRIPTION
The library already handles validation, and iat is not meant to be validated per jwt spec.

[be27206088f0a2ff959bd4bd2edabc97244700b8](https://github.com/Keats/jsonwebtoken/commit/be27206088f0a2ff959bd4bd2edabc97244700b8#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7)

https://github.com/Keats/jsonwebtoken/blob/master/src/validation.rs#L123